### PR TITLE
Add cash-equivalent swap agent and tests

### DIFF
--- a/backend/app/agents/__init__.py
+++ b/backend/app/agents/__init__.py
@@ -1,0 +1,6 @@
+"""Agent package exposing trading agents."""
+
+from .income_dividend_agent import IncomeDividendAgent
+from .cash_equivalent_swap_agent import CashEquivalentSwapAgent
+
+__all__ = ["IncomeDividendAgent", "CashEquivalentSwapAgent"]

--- a/backend/app/agents/cash_equivalent_swap_agent.py
+++ b/backend/app/agents/cash_equivalent_swap_agent.py
@@ -1,0 +1,42 @@
+"""CashEquivalentSwapAgent places cash-equivalent swap positions with risk controls."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class MarketEstimate:
+    """Represents market expectations for a swap leg."""
+
+    spread: float  # expected annualized spread vs. cash
+    variance: float  # variance of spread estimate
+
+
+class RiskLimitError(Exception):
+    """Raised when order sizing exceeds the agent's risk limit."""
+
+
+class CashEquivalentSwapAgent:
+    """Basic agent sizing cash-equivalent swap exposure using Kelly criterion."""
+
+    def __init__(self, capital: float, risk_limit: float = 0.05) -> None:
+        if capital <= 0:
+            raise ValueError("capital must be positive")
+        if not 0 < risk_limit <= 1:
+            raise ValueError("risk_limit must be between 0 and 1")
+        self.capital = capital
+        self.risk_limit = risk_limit
+
+    def position_size(self, estimate: MarketEstimate) -> float:
+        """Return position size respecting Kelly sizing and risk limits."""
+        if estimate.variance <= 0:
+            raise ValueError("variance must be positive")
+        kelly_fraction = estimate.spread / estimate.variance
+        suggested = kelly_fraction * self.capital
+        limit = self.capital * self.risk_limit
+        if abs(suggested) > limit:
+            raise RiskLimitError(
+                f"Position size {suggested:.2f} exceeds risk limit {limit:.2f}"
+            )
+        return suggested

--- a/trading_system/tests/test_cash_equivalent_swap_agent.py
+++ b/trading_system/tests/test_cash_equivalent_swap_agent.py
@@ -1,0 +1,22 @@
+import os, sys; sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+import pytest
+
+from backend.app.agents.cash_equivalent_swap_agent import (
+    CashEquivalentSwapAgent,
+    MarketEstimate,
+    RiskLimitError,
+)
+
+
+def test_position_size_within_limit():
+    agent = CashEquivalentSwapAgent(capital=100_000, risk_limit=0.3)
+    estimate = MarketEstimate(spread=0.01, variance=0.04)
+    size = agent.position_size(estimate)
+    assert size == pytest.approx(25_000.0)
+
+
+def test_position_size_exceeds_limit():
+    agent = CashEquivalentSwapAgent(capital=50_000, risk_limit=0.3)
+    estimate = MarketEstimate(spread=0.10, variance=0.01)
+    with pytest.raises(RiskLimitError):
+        agent.position_size(estimate)


### PR DESCRIPTION
## Summary
- implement `CashEquivalentSwapAgent` with Kelly-based sizing and risk limits
- expose new agent from `backend.app.agents`
- create package marker `backend/__init__.py`
- add unit tests verifying risk-limiting behaviour

## Testing
- `pip install fastapi==0.111.0 uvicorn[standard]==0.29.0 httpx==0.27.0`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68765bb7247083238dc31f18b7d29a6d