### PR TITLE
Update backend port and sanitize docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ Full-stack async trading platform using FastAPI backend and Next.js frontend.
 ./scripts/build_local.sh
 ```
 
+# Then open the dashboard
+
 Then open http://localhost:3000.
-=======
+
 # MAXX-AI Sample Package
 
 This archive contains a minimal yet runnable slice of the MAXX-AI stack:
@@ -27,4 +29,8 @@ docker compose -f infra/docker/docker-compose.yml up --build
 ```
 
 This will spin vLLM (GPU), orchestrator, Redpanda, RisingWave, and the backend in seconds.
+
+## Environment variables
+
+Copy `.env.example` to `.env` and provide values for the listed variables. Never commit real secrets to the repository.
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn[standard]
 numpy
+pydantic-settings

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,0 +1,9 @@
+from importlib import reload
+
+import backend.utils.settings as settings_module
+
+
+def test_settings_override(monkeypatch) -> None:
+    monkeypatch.setenv("ORCH_URL", "http://example.org")
+    reload(settings_module)
+    assert str(settings_module.settings.orch_url).rstrip("/") == "http://example.org"

--- a/backend/utils/settings.py
+++ b/backend/utils/settings.py
@@ -1,0 +1,13 @@
+"""Application settings using Pydantic BaseSettings."""
+
+from pydantic import AnyUrl, Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Load environment variables with defaults."""
+
+    orch_url: AnyUrl = Field("http://localhost:8080", env="ORCH_URL")
+
+
+settings = Settings()

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - redpanda
       - risingwave
     ports:
-      - '8000:8000'
+      - '8000:8001'
   frontend:
     build: ../../frontend
     env_file: ../../.env


### PR DESCRIPTION
## Summary
- sanitize README and add environment instructions
- expose backend on port 8001 and update compose file
- provide typed settings loader and unit tests

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876a76c3c648323861127b4c34fe57a