### PR TITLE
Add GKE deployment script and manifests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 # Environment configuration for MAXX-AI
 ORCH_URL=http://localhost:8080
 NEXT_PUBLIC_WS_URL=ws://localhost:8000/ws/agents
+PROJECT_ID=your-gcp-project
+GKE_CLUSTER_NAME=maxx-cluster
+GKE_REGION=us-central1
+GKE_NODE_COUNT=3

--- a/README.md
+++ b/README.md
@@ -34,3 +34,12 @@ This will spin vLLM (GPU), orchestrator, Redpanda, RisingWave, and the backend i
 
 Copy `.env.example` to `.env` and provide values for the listed variables. Never commit real secrets to the repository.
 
+
+## Deploying to GKE
+
+```bash
+source .env
+./scripts/deploy_gke.sh
+```
+
+This script builds container images with `gcloud builds submit` and applies manifests from `infra/k8s` to your configured cluster.

--- a/docs/gke_deployment.md
+++ b/docs/gke_deployment.md
@@ -1,0 +1,15 @@
+# GKE Deployment Guide
+
+This document outlines the steps to run MAXX-AI on Google Kubernetes Engine.
+
+1. Set up a Google Cloud project and enable the GKE API.
+2. Populate `.env` with your `PROJECT_ID`, `GKE_CLUSTER_NAME`, and `GKE_REGION`.
+3. Authenticate with `gcloud auth login` and `gcloud auth application-default login`.
+4. Execute:
+
+```bash
+source .env
+./scripts/deploy_gke.sh
+```
+
+The script creates the cluster if needed, builds and pushes container images, and applies the manifests located in `infra/k8s`.

--- a/infra/k8s/backend.yaml
+++ b/infra/k8s/backend.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: maxx-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: maxx-backend
+  template:
+    metadata:
+      labels:
+        app: maxx-backend
+    spec:
+      containers:
+      - name: backend
+        image: gcr.io/$PROJECT_ID/maxx-backend:latest
+        ports:
+        - containerPort: 8001
+        env:
+        - name: ORCH_URL
+          value: "http://localhost:8080"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: maxx-backend
+spec:
+  type: ClusterIP
+  selector:
+    app: maxx-backend
+  ports:
+  - name: http
+    port: 8001
+    targetPort: 8001

--- a/infra/k8s/frontend.yaml
+++ b/infra/k8s/frontend.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: maxx-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: maxx-frontend
+  template:
+    metadata:
+      labels:
+        app: maxx-frontend
+    spec:
+      containers:
+      - name: frontend
+        image: gcr.io/$PROJECT_ID/maxx-frontend:latest
+        ports:
+        - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: maxx-frontend
+spec:
+  type: LoadBalancer
+  selector:
+    app: maxx-frontend
+  ports:
+  - name: http
+    port: 80
+    targetPort: 3000

--- a/scripts/deploy_gke.sh
+++ b/scripts/deploy_gke.sh
@@ -1,3 +1,28 @@
 #!/bin/bash
-# Placeholder for GKE deployment script
-echo "Deploying to GKE..."
+# Deploy MAXX-AI services to Google Kubernetes Engine.
+set -euo pipefail
+
+: "${PROJECT_ID:?Set PROJECT_ID}"
+: "${GKE_CLUSTER_NAME:?Set GKE_CLUSTER_NAME}"
+: "${GKE_REGION:?Set GKE_REGION}"
+:GKE_NODE_COUNT="${GKE_NODE_COUNT:-3}"
+
+# Configure gcloud and create cluster if missing.
+gcloud config set project "$PROJECT_ID"
+if ! gcloud container clusters describe "$GKE_CLUSTER_NAME" --region "$GKE_REGION" >/dev/null 2>&1; then
+  gcloud container clusters create "$GKE_CLUSTER_NAME" \
+    --region "$GKE_REGION" \
+    --num-nodes "$GKE_NODE_COUNT" \
+    --machine-type "e2-standard-4"
+fi
+
+# Build and push images.
+gcloud auth configure-docker gcr.io --quiet
+gcloud builds submit --tag "gcr.io/${PROJECT_ID}/maxx-backend:latest" backend
+gcloud builds submit --tag "gcr.io/${PROJECT_ID}/maxx-frontend:latest" frontend
+
+# Deploy to cluster.
+gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --region "$GKE_REGION"
+kubectl apply -f infra/k8s
+
+echo "Deployment complete."


### PR DESCRIPTION
## Summary
- implement deploy_gke.sh for cluster creation and deployment
- add Kubernetes manifests for backend and frontend
- document environment variables and add GKE deployment guide
- update README with GKE instructions

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b189465c8323a3d82915c633e0ab