### PR TITLE
Add GKE deployment resources

### DIFF
--- a/Dockerfile.orchestrator
+++ b/Dockerfile.orchestrator
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY backend/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY backend ./backend
+COPY agent_orchestrator.py ./
+CMD ["python", "agent_orchestrator.py"]

--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ This will spin vLLM (GPU), orchestrator, Redpanda, RisingWave, and the backend i
 
 Copy `.env.example` to `.env` and provide values for the listed variables. Never commit real secrets to the repository.
 
+
+See `docs/gke_deploy.md` for Kubernetes deployment instructions.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn[standard]
 numpy
 pydantic-settings
+PyYAML

--- a/backend/tests/test_gke_manifests.py
+++ b/backend/tests/test_gke_manifests.py
@@ -1,0 +1,11 @@
+import pathlib
+import yaml
+
+MANIFEST_DIR = pathlib.Path(__file__).resolve().parents[2] / 'infra' / 'gke'
+
+
+def test_manifests_load() -> None:
+    for path in MANIFEST_DIR.glob('*.yaml'):
+        with path.open('r') as f:
+            docs = list(yaml.safe_load_all(f))
+            assert docs

--- a/docs/gke_deploy.md
+++ b/docs/gke_deploy.md
@@ -1,0 +1,29 @@
+# Deploying MAXX-AI to GKE
+
+This guide outlines the minimal steps to deploy the stack onto a Google Kubernetes Engine cluster.
+
+## Prerequisites
+
+- `gcloud` CLI configured with a project
+- Docker daemon authenticated to `gcr.io`
+- A GKE cluster
+
+## Environment variables
+
+Set the following variables before running the deployment script:
+
+```bash
+export GCP_PROJECT=<your-gcp-project>
+export GKE_CLUSTER=<your-cluster-name>
+export GKE_ZONE=<cluster-zone>
+```
+
+## Build and Deploy
+
+Run the helper script from the repository root:
+
+```bash
+./scripts/deploy_gke.sh
+```
+
+The script builds images, pushes them to `gcr.io/$GCP_PROJECT`, and applies the manifests in `infra/gke/`.

--- a/infra/gke/backend-deployment.yaml
+++ b/infra/gke/backend-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: maxx-ai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+      - name: backend
+        image: myrepo/backend:latest # replaced by deploy_gke.sh
+        env:
+        - name: ORCH_URL
+          value: http://orchestrator:8080
+        ports:
+        - containerPort: 8001
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8001
+          initialDelaySeconds: 5
+          periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: maxx-ai
+spec:
+  selector:
+    app: backend
+  ports:
+  - port: 8001
+    targetPort: 8001

--- a/infra/gke/frontend-deployment.yaml
+++ b/infra/gke/frontend-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: maxx-ai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: frontend
+        image: myrepo/frontend:latest # replaced by deploy_gke.sh
+        env:
+        - name: NEXT_PUBLIC_WS_URL
+          value: ws://backend:8001/ws/agents
+        ports:
+        - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: maxx-ai
+spec:
+  selector:
+    app: frontend
+  ports:
+  - port: 80
+    targetPort: 3000
+  type: LoadBalancer

--- a/infra/gke/llama3-deployment.yaml
+++ b/infra/gke/llama3-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llama3
+  namespace: maxx-ai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: llama3
+  template:
+    metadata:
+      labels:
+        app: llama3
+    spec:
+      containers:
+      - name: llama3
+        image: ghcr.io/vllm/vllm-engine:2.0
+        ports:
+        - containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llama3
+  namespace: maxx-ai
+spec:
+  selector:
+    app: llama3
+  ports:
+  - port: 8000
+    targetPort: 8000

--- a/infra/gke/namespace.yaml
+++ b/infra/gke/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: maxx-ai

--- a/infra/gke/orchestrator-deployment.yaml
+++ b/infra/gke/orchestrator-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: orchestrator
+  namespace: maxx-ai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: orchestrator
+  template:
+    metadata:
+      labels:
+        app: orchestrator
+    spec:
+      containers:
+      - name: orchestrator
+        image: myrepo/orchestrator:latest # replaced by deploy_gke.sh
+        env:
+        - name: MODEL_ENDPOINT
+          value: "http://llama3:8000/v1"
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: orchestrator
+  namespace: maxx-ai
+spec:
+  selector:
+    app: orchestrator
+  ports:
+  - port: 8080
+    targetPort: 8080

--- a/infra/gke/redpanda-deployment.yaml
+++ b/infra/gke/redpanda-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda
+  namespace: maxx-ai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redpanda
+  template:
+    metadata:
+      labels:
+        app: redpanda
+    spec:
+      containers:
+      - name: redpanda
+        image: redpandadata/redpanda:v23.2
+        args: ["start","--mode","dev-container"]
+        ports:
+        - containerPort: 9092
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: maxx-ai
+spec:
+  selector:
+    app: redpanda
+  ports:
+  - port: 9092
+    targetPort: 9092

--- a/infra/gke/risingwave-deployment.yaml
+++ b/infra/gke/risingwave-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: risingwave
+  namespace: maxx-ai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: risingwave
+  template:
+    metadata:
+      labels:
+        app: risingwave
+    spec:
+      containers:
+      - name: risingwave
+        image: risingwavelabs/risingwave:1.7
+        ports:
+        - containerPort: 4567
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: risingwave
+  namespace: maxx-ai
+spec:
+  selector:
+    app: risingwave
+  ports:
+  - port: 4567
+    targetPort: 4567

--- a/scripts/deploy_gke.sh
+++ b/scripts/deploy_gke.sh
@@ -1,3 +1,38 @@
 #!/bin/bash
-# Placeholder for GKE deployment script
-echo "Deploying to GKE..."
+set -euo pipefail
+
+: "${GCP_PROJECT:?GCP_PROJECT not set}"
+: "${GKE_CLUSTER:?GKE_CLUSTER not set}"
+: "${GKE_ZONE:?GKE_ZONE not set}"
+
+REGISTRY="gcr.io/${GCP_PROJECT}"
+BACKEND_IMG="${REGISTRY}/backend:latest"
+ORCH_IMG="${REGISTRY}/orchestrator:latest"
+FRONTEND_IMG="${REGISTRY}/frontend:latest"
+
+# Build images
+docker build -t "$BACKEND_IMG" -f backend/Dockerfile backend
+docker build -t "$ORCH_IMG" -f Dockerfile.orchestrator .
+docker build -t "$FRONTEND_IMG" -f frontend/Dockerfile frontend
+
+# Push images
+docker push "$BACKEND_IMG"
+docker push "$ORCH_IMG"
+docker push "$FRONTEND_IMG"
+
+# Update manifests with project images
+sed "s~myrepo/backend:latest~$BACKEND_IMG~" infra/gke/backend-deployment.yaml > /tmp/backend.yaml
+sed "s~myrepo/orchestrator:latest~$ORCH_IMG~" infra/gke/orchestrator-deployment.yaml > /tmp/orchestrator.yaml
+sed "s~myrepo/frontend:latest~$FRONTEND_IMG~" infra/gke/frontend-deployment.yaml > /tmp/frontend.yaml
+
+# Configure kubectl
+gcloud container clusters get-credentials "$GKE_CLUSTER" --zone "$GKE_ZONE" --project "$GCP_PROJECT"
+
+# Deploy resources
+kubectl apply -f infra/gke/namespace.yaml
+kubectl apply -f infra/gke/redpanda-deployment.yaml
+kubectl apply -f infra/gke/risingwave-deployment.yaml
+kubectl apply -f infra/gke/llama3-deployment.yaml
+kubectl apply -f /tmp/orchestrator.yaml
+kubectl apply -f /tmp/backend.yaml
+kubectl apply -f /tmp/frontend.yaml


### PR DESCRIPTION
## Summary
- implement Dockerfile for the orchestrator service
- add Kubernetes manifests for GKE deployment
- create deployment helper script
- document GKE deployment steps
- ensure manifests load in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b189465c8323a3d82915c633e0ab