### PR TITLE
Add GKE deployment script and manifests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 # Environment configuration for MAXX-AI
 ORCH_URL=http://localhost:8080
 NEXT_PUBLIC_WS_URL=ws://localhost:8000/ws/agents
+# GKE deployment variables
+GCP_PROJECT=your-project-id
+GKE_CLUSTER=maxx-ai
+GKE_ZONE=us-central1-a
+IMAGE_TAG=latest

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
 # Documentation
 
 This folder contains design docs and operational guides for MAXX-AI.
+
+- [GKE Deployment Guide](gke_deploy.md)

--- a/docs/gke_deploy.md
+++ b/docs/gke_deploy.md
@@ -1,0 +1,27 @@
+# Deploying MAXX-AI on Google Kubernetes Engine
+
+This guide outlines the steps to launch the MAXX-AI stack on GKE. It assumes you have `gcloud` and `kubectl` installed and authenticated.
+
+1. **Create a Cluster**
+   ```bash
+   gcloud container clusters create "$GKE_CLUSTER" \
+     --zone "$GKE_ZONE" --project "$GCP_PROJECT"
+   ```
+
+2. **Build and Push Images**
+   ```bash
+   IMAGE_TAG=latest
+   docker build -t gcr.io/$GCP_PROJECT/maxx-orchestrator:$IMAGE_TAG -f backend/Dockerfile .
+   docker build -t gcr.io/$GCP_PROJECT/maxx-backend:$IMAGE_TAG -f backend/Dockerfile backend
+   docker build -t gcr.io/$GCP_PROJECT/maxx-frontend:$IMAGE_TAG -f frontend/Dockerfile frontend
+   docker push gcr.io/$GCP_PROJECT/maxx-orchestrator:$IMAGE_TAG
+   docker push gcr.io/$GCP_PROJECT/maxx-backend:$IMAGE_TAG
+   docker push gcr.io/$GCP_PROJECT/maxx-frontend:$IMAGE_TAG
+   ```
+
+3. **Deploy Manifests**
+   ```bash
+   ./scripts/deploy_gke.sh
+   ```
+
+The script retrieves cluster credentials and applies all manifests from `infra/gke/`. Ensure your `.env` file defines the required variables (`GCP_PROJECT`, `GKE_CLUSTER`, `GKE_ZONE`, `IMAGE_TAG`).

--- a/infra/gke/README.md
+++ b/infra/gke/README.md
@@ -1,0 +1,12 @@
+# GKE Deployment Manifests
+
+This directory contains Kubernetes manifests for running MAXX-AI on Google Kubernetes Engine.
+
+Apply them with:
+
+```bash
+scripts/deploy_gke.sh
+```
+
+Ensure the container images referenced in the manifests are built and pushed to
+your Google Container Registry before applying.

--- a/infra/gke/backend.yaml
+++ b/infra/gke/backend.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: maxx-ai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+        - name: backend
+          image: gcr.io/${GCP_PROJECT}/maxx-backend:${IMAGE_TAG}
+          env:
+            - name: ORCH_URL
+              value: http://orchestrator:8080
+          ports:
+            - containerPort: 8001
+          securityContext:
+            readOnlyRootFilesystem: true
+          resources:
+            limits:
+              cpu: "1"
+              memory: "512Mi"
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: maxx-ai
+spec:
+  selector:
+    app: backend
+  ports:
+    - port: 8000
+      targetPort: 8001
+  type: ClusterIP

--- a/infra/gke/frontend.yaml
+++ b/infra/gke/frontend.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: maxx-ai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: gcr.io/${GCP_PROJECT}/maxx-frontend:${IMAGE_TAG}
+          env:
+            - name: NEXT_PUBLIC_WS_URL
+              value: ws://backend:8000/ws/agents
+          ports:
+            - containerPort: 3000
+          securityContext:
+            readOnlyRootFilesystem: true
+          resources:
+            limits:
+              cpu: "1"
+              memory: "256Mi"
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: maxx-ai
+spec:
+  selector:
+    app: frontend
+  ports:
+    - port: 80
+      targetPort: 3000
+  type: LoadBalancer

--- a/infra/gke/llama3.yaml
+++ b/infra/gke/llama3.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llama3
+  namespace: maxx-ai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: llama3
+  template:
+    metadata:
+      labels:
+        app: llama3
+    spec:
+      containers:
+        - name: llama3
+          image: ghcr.io/vllm/vllm-engine:2.0
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+          ports:
+            - containerPort: 8000
+          securityContext:
+            readOnlyRootFilesystem: true
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llama3
+  namespace: maxx-ai
+spec:
+  selector:
+    app: llama3
+  ports:
+    - port: 8000
+      targetPort: 8000

--- a/infra/gke/namespace.yaml
+++ b/infra/gke/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: maxx-ai

--- a/infra/gke/orchestrator.yaml
+++ b/infra/gke/orchestrator.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: orchestrator
+  namespace: maxx-ai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: orchestrator
+  template:
+    metadata:
+      labels:
+        app: orchestrator
+    spec:
+      containers:
+        - name: orchestrator
+          image: gcr.io/${GCP_PROJECT}/maxx-orchestrator:${IMAGE_TAG}
+          ports:
+            - containerPort: 8080
+          securityContext:
+            readOnlyRootFilesystem: true
+          resources:
+            limits:
+              cpu: "1"
+              memory: "512Mi"
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: orchestrator
+  namespace: maxx-ai
+spec:
+  selector:
+    app: orchestrator
+  ports:
+    - port: 8080
+      targetPort: 8080
+  type: ClusterIP

--- a/infra/gke/redpanda.yaml
+++ b/infra/gke/redpanda.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda
+  namespace: maxx-ai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redpanda
+  template:
+    metadata:
+      labels:
+        app: redpanda
+    spec:
+      containers:
+        - name: redpanda
+          image: redpandadata/redpanda:v23.2
+          args: ["start", "--mode", "dev-container"]
+          ports:
+            - containerPort: 9092
+          resources:
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+          securityContext:
+            readOnlyRootFilesystem: true
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: maxx-ai
+spec:
+  selector:
+    app: redpanda
+  ports:
+    - port: 9092
+      targetPort: 9092

--- a/infra/gke/risingwave.yaml
+++ b/infra/gke/risingwave.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: risingwave
+  namespace: maxx-ai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: risingwave
+  template:
+    metadata:
+      labels:
+        app: risingwave
+    spec:
+      containers:
+        - name: risingwave
+          image: risingwavelabs/risingwave:1.7
+          ports:
+            - containerPort: 4567
+          securityContext:
+            readOnlyRootFilesystem: true
+          resources:
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: risingwave
+  namespace: maxx-ai
+spec:
+  selector:
+    app: risingwave
+  ports:
+    - port: 4567
+      targetPort: 4567

--- a/scripts/deploy_gke.sh
+++ b/scripts/deploy_gke.sh
@@ -1,3 +1,24 @@
 #!/bin/bash
-# Placeholder for GKE deployment script
-echo "Deploying to GKE..."
+# Deploy MAXX-AI services to an existing GKE cluster.
+# Requires gcloud and kubectl to be installed and authenticated.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+: "${GCP_PROJECT:?Set GCP_PROJECT}"
+: "${GKE_CLUSTER:?Set GKE_CLUSTER}"
+: "${GKE_ZONE:?Set GKE_ZONE}"
+: "${IMAGE_TAG:=latest}"
+
+# Get cluster credentials
+"$(command -v gcloud)" container clusters get-credentials "$GKE_CLUSTER" \
+    --zone "$GKE_ZONE" --project "$GCP_PROJECT"
+
+# Apply manifests
+kubectl apply -f "$ROOT_DIR/infra/gke/namespace.yaml"
+for f in "$ROOT_DIR"/infra/gke/*.yaml; do
+    [ "$f" != "$ROOT_DIR/infra/gke/namespace.yaml" ] || continue
+    kubectl apply -f "$f"
+done
+
+echo "Deployment complete."


### PR DESCRIPTION
## Summary
- provide Kubernetes manifests under `infra/gke`
- add a deployment script `deploy_gke.sh`
- document deployment steps for GKE
- expose GKE env vars in `.env.example`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b189465c8323a3d82915c633e0ab