### PR TITLE
Add production strategy weights

### DIFF
--- a/config/strategies.yml
+++ b/config/strategies.yml
@@ -1,0 +1,4 @@
+weights:
+  momentum: 0.50
+  sentiment: 0.30
+  mean_reversion: 0.20


### PR DESCRIPTION
## Summary
- add `config/strategies.yml` with target strategy weights
- run unit tests to ensure nothing breaks

## Testing
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_6876d27965e08323bfa8f711e861bad4