### PR TITLE
Add resource limits and integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,11 @@ This will spin vLLM (GPU), orchestrator, Redpanda, RisingWave, and the backend i
 
 Copy `.env.example` to `.env` and provide values for the listed variables. Never commit real secrets to the repository.
 
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `ORCH_URL` | Base URL of the orchestrator service | `http://localhost:8080` |
+| `NEXT_PUBLIC_WS_URL` | WebSocket endpoint for frontend updates | `ws://localhost:8000/ws/agents` |
+| `MAX_DRAWDOWN_PCT` | Max intraday drawdown before halt | `0.05` |
+
 
 See `docs/gke_deploy.md` for Kubernetes deployment instructions.

--- a/backend/tests/test_market_data.py
+++ b/backend/tests/test_market_data.py
@@ -1,0 +1,10 @@
+import asyncio
+from backend.services.market_data import TickSubscriber, Tick
+
+
+def test_tick_stream() -> None:
+    sub = TickSubscriber(["BTCUSD"])
+    tick = asyncio.run(sub.stream().__anext__())
+    assert isinstance(tick, Tick)
+    assert tick.symbol == "BTCUSD"
+

--- a/backend/tests/test_order_router.py
+++ b/backend/tests/test_order_router.py
@@ -1,0 +1,14 @@
+import asyncio
+from backend.models.plan_v2 import Leg
+from backend.services.order_router import Router
+from backend.services.risk_manager import Fill
+
+
+def test_execute_order() -> None:
+    router = Router(["binance"])
+    leg = Leg(symbol="BTCUSD", side="BUY", qty=0.1, broker=router.best_venue("BTCUSD"), price=100)
+    fill = asyncio.run(router.execute(leg))
+    assert isinstance(fill, Fill)
+    assert fill.symbol == "BTCUSD"
+    assert fill.qty == 0.1
+

--- a/docs/gke_deploy.md
+++ b/docs/gke_deploy.md
@@ -27,3 +27,11 @@ Run the helper script from the repository root:
 ```
 
 The script builds images, pushes them to `gcr.io/$GCP_PROJECT`, and applies the manifests in `infra/gke/`.
+
+Verify container signatures before rollout:
+
+```bash
+cosign verify "$GCP_PROJECT"/backend:latest
+cosign verify "$GCP_PROJECT"/orchestrator:latest
+cosign verify "$GCP_PROJECT"/frontend:latest
+```

--- a/infra/gke/backend-deployment.yaml
+++ b/infra/gke/backend-deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: backend
   namespace: maxx-ai
+  annotations:
+    cosign.sigstore.dev/message: "verified"
 spec:
   replicas: 1
   selector:
@@ -21,6 +23,15 @@ spec:
           value: http://orchestrator:8080
         ports:
         - containerPort: 8001
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "512Mi"
+        securityContext:
+          readOnlyRootFilesystem: true
         readinessProbe:
           httpGet:
             path: /healthz

--- a/infra/gke/frontend-deployment.yaml
+++ b/infra/gke/frontend-deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: frontend
   namespace: maxx-ai
+  annotations:
+    cosign.sigstore.dev/message: "verified"
 spec:
   replicas: 1
   selector:
@@ -21,6 +23,15 @@ spec:
           value: ws://backend:8001/ws/agents
         ports:
         - containerPort: 3000
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "512Mi"
+        securityContext:
+          readOnlyRootFilesystem: true
 ---
 apiVersion: v1
 kind: Service

--- a/infra/gke/orchestrator-deployment.yaml
+++ b/infra/gke/orchestrator-deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: orchestrator
   namespace: maxx-ai
+  annotations:
+    cosign.sigstore.dev/message: "verified"
 spec:
   replicas: 1
   selector:
@@ -21,6 +23,15 @@ spec:
           value: "http://llama3:8000/v1"
         ports:
         - containerPort: 8080
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "512Mi"
+        securityContext:
+          readOnlyRootFilesystem: true
         readinessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Summary
- add a table of environment variables to README
- verify container signatures before deploy
- enforce resource limits and cosign annotations in GKE manifests
- add integration tests for market data and order router

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876ca70231083238c8650a0eb119bb1