### PR TITLE
Add fast simulation runner

### DIFF
--- a/backend/pipelines/run_sim.py
+++ b/backend/pipelines/run_sim.py
@@ -1,0 +1,37 @@
+"""Run accelerated trading simulation."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from typing import Any, Dict
+
+from backend.services.trading_engine import TradingEngine
+
+
+async def run_sim(hours: float, starting_balance: float) -> Dict[str, Any]:
+    """Run engine for specified hours and return final stats."""
+    engine = TradingEngine(starting_balance=starting_balance, tick_delay=0.0, order_delay=0.0)
+    ticks = int(hours * 3600 / 0.5)
+    await engine.start(ticks=ticks, ignore_session=True)
+    return {
+        "start_balance": starting_balance,
+        "end_balance": engine.risk.balance,
+        "unrealized_pnl": engine.risk.unrealized_pnl(),
+        "total_fills": len(engine.risk.fills),
+    }
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--hours", type=float, default=72.0)
+    parser.add_argument("--balances", type=float, nargs="*", default=[100, 1000, 2000])
+    args = parser.parse_args()
+
+    for bal in args.balances:
+        res = await run_sim(args.hours, bal)
+        print(res)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/services/market_data.py
+++ b/backend/services/market_data.py
@@ -19,14 +19,15 @@ class Tick:
 class TickSubscriber:
     """Simulates subscription to a live market data feed."""
 
-    def __init__(self, symbols: Iterable[str]):
+    def __init__(self, symbols: Iterable[str], delay: float = 0.5):
         self.symbols = list(symbols)
+        self.delay = float(delay)
 
     async def stream(self) -> AsyncGenerator[Tick, None]:
         """Yield ticks indefinitely."""
         prices = {s: random.uniform(100, 50000) for s in self.symbols}
         while True:
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(self.delay)
             sym = random.choice(self.symbols)
             delta = random.uniform(-0.5, 0.5)
             prices[sym] = max(1.0, prices[sym] * (1 + delta / 100))

--- a/backend/services/order_router.py
+++ b/backend/services/order_router.py
@@ -12,15 +12,16 @@ from .risk_manager import Fill
 class Router:
     """Route orders to the best venue and simulate fills."""
 
-    def __init__(self, venues: Iterable[str] | None = None) -> None:
+    def __init__(self, venues: Iterable[str] | None = None, delay: float = 0.1) -> None:
         self.venues = list(venues or ["binance", "coinbase", "bybit"])
+        self.delay = float(delay)
 
     def best_venue(self, symbol: str) -> str:  # noqa: D401 - simple wrapper
         """Return the best venue for symbol."""
         return random.choice(self.venues)
 
     async def execute(self, leg: "Leg") -> Fill:
-        await asyncio.sleep(0.1)  # simulate network delay
+        await asyncio.sleep(self.delay)
         price = leg.price or 0.0
         return Fill(
             order_id=f"{leg.symbol}-{random.randint(1, 999999)}",

--- a/backend/services/risk_manager.py
+++ b/backend/services/risk_manager.py
@@ -18,10 +18,10 @@ class Fill:
 class RiskSentinel:
     """Simple risk management with configurable drawdown halt."""
 
-    def __init__(self, max_dd: float | None = None) -> None:
+    def __init__(self, max_dd: float | None = None, starting_balance: float = 100_000.0) -> None:
         self.max_dd = max_dd if max_dd is not None else settings.max_drawdown_pct
         self.max_dd = max(0.0, min(1.0, self.max_dd))
-        self.balance = 100_000.0
+        self.balance = float(starting_balance)
         self.day_start = self.balance
         self.halt = False
         self.fills: list[Fill] = []

--- a/backend/tests/test_run_sim.py
+++ b/backend/tests/test_run_sim.py
@@ -1,0 +1,8 @@
+from backend.pipelines.run_sim import run_sim
+import asyncio
+
+
+def test_run_sim_returns_dict() -> None:
+    res = asyncio.run(run_sim(0.001, 100.0))
+    assert "end_balance" in res
+


### PR DESCRIPTION
## Summary
- allow variable delay in market data feed and order router
- add starting balance param to risk manager
- expose config and tick controls in trading engine
- script for running quick sims
- test the new run_sim helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876d57c7b6c832395d00bada59e55f2