### PR TITLE
Add configurable risk and sim script

### DIFF
--- a/backend/services/market_data.py
+++ b/backend/services/market_data.py
@@ -19,14 +19,25 @@ class Tick:
 class TickSubscriber:
     """Simulates subscription to a live market data feed."""
 
-    def __init__(self, symbols: Iterable[str]):
+    def __init__(self, symbols: Iterable[str], delay: float = 0.5) -> None:
+        """Create a tick subscriber.
+
+        Parameters
+        ----------
+        symbols:
+            Iterable of symbol strings to subscribe to.
+        delay:
+            Delay between ticks in seconds.
+        """
+
         self.symbols = list(symbols)
+        self.delay = max(0.0, delay)
 
     async def stream(self) -> AsyncGenerator[Tick, None]:
         """Yield ticks indefinitely."""
         prices = {s: random.uniform(100, 50000) for s in self.symbols}
         while True:
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(self.delay)
             sym = random.choice(self.symbols)
             delta = random.uniform(-0.5, 0.5)
             prices[sym] = max(1.0, prices[sym] * (1 + delta / 100))

--- a/backend/services/risk_manager.py
+++ b/backend/services/risk_manager.py
@@ -18,10 +18,20 @@ class Fill:
 class RiskSentinel:
     """Simple risk management with configurable drawdown halt."""
 
-    def __init__(self, max_dd: float | None = None) -> None:
+    def __init__(self, max_dd: float | None = None, start_balance: float = 100_000.0) -> None:
+        """Create a risk sentinel.
+
+        Parameters
+        ----------
+        max_dd:
+            Maximum intraday drawdown allowed before halting trading.
+        start_balance:
+            Starting account equity for the session.
+        """
+
         self.max_dd = max_dd if max_dd is not None else settings.max_drawdown_pct
         self.max_dd = max(0.0, min(1.0, self.max_dd))
-        self.balance = 100_000.0
+        self.balance = float(start_balance)
         self.day_start = self.balance
         self.halt = False
         self.fills: list[Fill] = []

--- a/backend/tests/test_engine.py
+++ b/backend/tests/test_engine.py
@@ -1,0 +1,20 @@
+import asyncio
+
+from backend.services.trading_engine import TradingEngine
+from backend.services.market_data import TickSubscriber, Tick
+from backend.services.risk_manager import RiskSentinel
+
+
+class DummySub(TickSubscriber):
+    def __init__(self) -> None:
+        super().__init__(["BTCUSD"], delay=0.0)
+
+    async def stream(self):
+        for _ in range(3):
+            yield Tick(symbol="BTCUSD", price=100.0)
+
+
+def test_engine_run() -> None:
+    engine = TradingEngine(tick_sub=DummySub(), risk=RiskSentinel(start_balance=100))
+    asyncio.run(engine.run(3))
+    assert isinstance(engine.risk.balance, float)

--- a/backend/tests/test_risk_manager.py
+++ b/backend/tests/test_risk_manager.py
@@ -6,3 +6,8 @@ def test_drawdown_halt() -> None:
     fill = Fill(order_id="1", symbol="BTCUSD", side="BUY", qty=50, price=100)
     risk.update(fill)
     assert risk.halt
+
+
+def test_start_balance() -> None:
+    risk = RiskSentinel(start_balance=500)
+    assert risk.balance == 500

--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -1,0 +1,44 @@
+"""Run an accelerated trading simulation from the command line."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from typing import Tuple
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from backend.services.market_data import TickSubscriber
+from backend.services.risk_manager import RiskSentinel
+from backend.services.trading_engine import TradingEngine
+
+
+async def simulate(initial_balance: float, hours: int = 72) -> Tuple[float, int]:
+    """Run the engine for ``hours`` trading hours and return final balance.
+
+    The simulation runs without tick delays to complete quickly.
+    Each hour is approximated by one tick.
+    """
+
+    ticks = int(hours)
+    sub = TickSubscriber(["BTCUSD", "ETHUSD", "EURUSD"], delay=0.0)
+    engine = TradingEngine(tick_sub=sub, risk=RiskSentinel(start_balance=initial_balance))
+    await engine.run(ticks)
+    return engine.risk.balance, ticks
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run trading simulation")
+    parser.add_argument("initial", type=float, help="initial balance")
+    parser.add_argument("--hours", type=int, default=72, help="simulation hours")
+    args = parser.parse_args()
+    final_balance, ticks = asyncio.run(simulate(args.initial, args.hours))
+    print(f"start={args.initial} final={final_balance:.2f} ticks={ticks}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow RiskSentinel initial balance parameter
- support delay parameter for TickSubscriber
- make TradingEngine dependencies configurable and add a finite-run mode
- add CLI script to run accelerated simulations
- include tests for new features

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`
- `python scripts/run_simulation.py 100 --hours 72 | tail -n 1`
- `python scripts/run_simulation.py 1000 --hours 72 | tail -n 1`
- `python scripts/run_simulation.py 2000 --hours 72 | tail -n 1`

------
https://chatgpt.com/codex/tasks/task_e_6876d57c7b6c832395d00bada59e55f2