### PR TITLE
Add GKE k8s manifests

### DIFF
--- a/backend/tests/test_k8s_manifests.py
+++ b/backend/tests/test_k8s_manifests.py
@@ -1,0 +1,11 @@
+import pathlib
+import yaml
+
+MANIFEST_DIR = pathlib.Path(__file__).resolve().parents[2] / 'k8s'
+
+
+def test_manifests_load() -> None:
+    for path in MANIFEST_DIR.glob('*.yaml'):
+        with path.open('r') as f:
+            docs = list(yaml.safe_load_all(f))
+            assert docs

--- a/docs/gke_deploy.md
+++ b/docs/gke_deploy.md
@@ -28,6 +28,18 @@ Run the helper script from the repository root:
 
 The script builds images, pushes them to `gcr.io/$GCP_PROJECT`, and applies the manifests in `infra/gke/`.
 
+### Manual deployment
+
+If you prefer to manage manifests yourself, apply the files in the `k8s/` directory:
+
+```bash
+kubectl apply -f k8s/backend-deployment.yaml -n maxx-ai
+kubectl apply -f k8s/backend-service.yaml -n maxx-ai
+kubectl apply -f k8s/frontend-deployment.yaml -n maxx-ai
+kubectl apply -f k8s/frontend-service.yaml -n maxx-ai
+kubectl apply -f k8s/ingress.yaml -n maxx-ai   # optional
+```
+
 Verify container signatures before rollout:
 
 ```bash

--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: maxx-backend
+  namespace: maxx-ai
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: maxx-backend
+  template:
+    metadata:
+      labels:
+        app: maxx-backend
+    spec:
+      containers:
+      - name: maxx-backend
+        image: us-central1-docker.pkg.dev/maxx-ai-control-center/maxx-docker-repo/backend:latest
+        ports:
+        - containerPort: 8000
+        resources:
+          requests:
+            cpu: 250m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi

--- a/k8s/backend-service.yaml
+++ b/k8s/backend-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: maxx-backend-service
+  namespace: maxx-ai
+spec:
+  type: LoadBalancer
+  selector:
+    app: maxx-backend
+  ports:
+  - protocol: TCP
+    port: 8000
+    targetPort: 8000

--- a/k8s/frontend-deployment.yaml
+++ b/k8s/frontend-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: maxx-frontend
+  namespace: maxx-ai
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: maxx-frontend
+  template:
+    metadata:
+      labels:
+        app: maxx-frontend
+    spec:
+      containers:
+      - name: maxx-frontend
+        image: us-central1-docker.pkg.dev/maxx-ai-control-center/maxx-docker-repo/frontend:latest
+        ports:
+        - containerPort: 3000
+        resources:
+          requests:
+            cpu: 250m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi

--- a/k8s/frontend-service.yaml
+++ b/k8s/frontend-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: maxx-frontend-service
+  namespace: maxx-ai
+spec:
+  type: LoadBalancer
+  selector:
+    app: maxx-frontend
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 3000

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: maxx-ingress
+  namespace: maxx-ai
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: maxx-ingress-ip
+    networking.gke.io/managed-certificates: maxx-cert
+spec:
+  rules:
+  - host: maxx-control-center.yourdomain.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: maxx-frontend-service
+            port:
+              number: 80


### PR DESCRIPTION
## Summary
- provide production-ready deployment YAML under `k8s/`
- document manual `kubectl` usage in the GKE guide
- ensure new manifests parse in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876e78285a0832380cb7687fa986e37