### PR TITLE
Fix Cloud Run deploys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-slim
 WORKDIR /app
-COPY requirements.txt .
+COPY backend/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY . .
+COPY backend/ ./
 CMD ["sh", "-c", "uvicorn api.main:app --host 0.0.0.0 --port ${PORT:-8000}"]
 

--- a/README.md
+++ b/README.md
@@ -40,3 +40,16 @@ Copy `.env.example` to `.env` and provide values for the listed variables. Never
 
 
 See `docs/gke_deploy.md` for Kubernetes deployment instructions.
+
+## Deploy to Cloud Run
+
+Build and deploy the backend container using the provided `Dockerfile`:
+
+```bash
+gcloud builds submit --tag gcr.io/PROJECT_ID/maxx-backend
+gcloud run deploy maxx-backend --image gcr.io/PROJECT_ID/maxx-backend --platform managed --region REGION
+```
+
+Cloud Run sets the `$PORT` environment variable automatically. The images and
+Dockerfiles have been updated to respect this value.
+

--- a/backend/api/orchestrator.py
+++ b/backend/api/orchestrator.py
@@ -1,25 +1,32 @@
-from fastapi import FastAPI
+import os
+
+import uvicorn
 from autogen import Agent, GroupChat, config_list_from_json
-import os, uvicorn
+from fastapi import FastAPI
 
 MODEL_URL = os.getenv("MODEL_ENDPOINT", "http://localhost:8000/v1")
 cfg = [{"model": "llama3", "base_url": MODEL_URL}]
 
-market_scout   = Agent("Scout", cfg, tools=["market_feed"])
-alpha_research = Agent("Researcher", cfg, tools=["backtest", "python"])
-risk_sentinel  = Agent("Risk", cfg, tools=["risk_api"])
-governor       = Agent("Governor", cfg, tools=["balance_api", "order_api"])
-
-chat = GroupChat(
-    agents=[market_scout, alpha_research, risk_sentinel, governor],
-    messages=[{"role":"system","content":"Goal: maximize Sharpe with ≤5% DD."}],
-    max_turns=8,
-)
+def get_chat() -> GroupChat:
+    """Instantiate and cache the group chat."""
+    if not hasattr(get_chat, "_chat"):
+        market_scout = Agent("Scout", cfg, tools=["market_feed"])
+        alpha_research = Agent("Researcher", cfg, tools=["backtest", "python"])
+        risk_sentinel = Agent("Risk", cfg, tools=["risk_api"])
+        governor = Agent("Governor", cfg, tools=["balance_api", "order_api"])
+        get_chat._chat = GroupChat(
+            agents=[market_scout, alpha_research, risk_sentinel, governor],
+            messages=[{"role": "system", "content": "Goal: maximize Sharpe with ≤5% DD."}],
+            max_turns=8,
+        )
+    return get_chat._chat
 
 app = FastAPI()
 
+
 @app.post("/orchestrate")
-async def orchestrate():
+async def orchestrate() -> dict[str, str]:
+    chat = get_chat()
     result = chat.run()
     return {"plan": result}
 
@@ -27,5 +34,13 @@ async def orchestrate():
 def healthz(): 
     return {"ok": True}
 
+def server_port() -> int:
+    """Return service port from $PORT or default to 8080."""
+    return int(os.getenv("PORT", "8080"))
+
+
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8080)
+    uvicorn.run(app, host="0.0.0.0", port=server_port())
+
+
+

--- a/backend/tests/test_orchestrator_port.py
+++ b/backend/tests/test_orchestrator_port.py
@@ -1,0 +1,9 @@
+from backend.api.orchestrator import server_port
+
+
+def test_server_port_env(monkeypatch):
+    monkeypatch.setenv("PORT", "5555")
+    assert server_port() == 5555
+    monkeypatch.delenv("PORT", raising=False)
+    assert server_port() == 8080
+

--- a/scripts/deploy_gke.sh
+++ b/scripts/deploy_gke.sh
@@ -11,9 +11,9 @@ ORCH_IMG="${REGISTRY}/orchestrator:latest"
 FRONTEND_IMG="${REGISTRY}/frontend:latest"
 
 # Build images
-docker build -t "$BACKEND_IMG" -f backend/Dockerfile backend
+docker build -t "$BACKEND_IMG" -f docker/backend.Dockerfile backend
 docker build -t "$ORCH_IMG" -f Dockerfile.orchestrator .
-docker build -t "$FRONTEND_IMG" -f frontend/Dockerfile frontend
+docker build -t "$FRONTEND_IMG" -f docker/frontend.Dockerfile frontend
 
 # Push images
 docker push "$BACKEND_IMG"


### PR DESCRIPTION
## Summary
- add Cloud Run compatible Dockerfile
- respect `$PORT` in backend Docker image
- expose `server_port` helper and lazy init for orchestrator agent chat
- fix deploy script paths
- document Cloud Run deployment
- test `server_port` handling

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877392af5d08323a1f5165ce4d756fd