### PR TITLE
Add config, proto, docs and system info

### DIFF
--- a/config/agent_config.yaml
+++ b/config/agent_config.yaml
@@ -1,0 +1,22 @@
+market_data:
+  retry_backoff_ms: 250
+  resubscribe_sec: 300
+  feeds: ["binance", "coinbase", "bybit", "oanda"]
+alpha:
+  weights: { momentum: 0.5, mean_reversion: 0.3, breakout: 0.2, sentiment: 0.1 }
+  reweight_cron: "10 0 * * *"
+  nlp_model: "llama3-lora-trading"
+risk:
+  max_trade_risk_pct: 0.3
+  daily_drawdown_pct: 5.0
+  slippage_limit_pct: 0.2
+  hard_kill_pct: 7.0
+exec:
+  maker_rebate_threshold_bps: 1.0
+  fallback_on_reject: true
+sentiment:
+  score_feed: "risingwave://sentiment_30m"
+  news_apis: ["newsapi.org", "twitter", "reddit"]
+meta_governor:
+  enable_rl: true
+  retrain_cron: "5 1 * * *"

--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -1,0 +1,15 @@
+# MAXX-Ai Agents Overview
+
+This document summarizes agent roles defined in the MAXX-Ai Agents Specification.
+Refer to the root `AGENTS.md` for the full specification and update both files when adding or modifying agents.
+
+| Agent | Description |
+|-------|-------------|
+| MarketDataAgent | Normalizes exchange feeds and publishes ticks to the bus |
+| AlphaAgent | Generates trading signals using momentum, mean reversion, breakout and sentiment models |
+| RiskSentinel | Provides real-time risk controls and kill switch functionality |
+| ExecutionAgent | Routes orders to brokers and reconciles fills |
+| MetaGovernor | Performs RL/AutoML to adjust AlphaAgent weights |
+| PortfolioAgent | Aggregates PnL and manages payouts |
+| SessionClock | Emits global session events |
+| SentimentAgent | Processes news and social feeds to produce sentiment scores |

--- a/proto/execution.proto
+++ b/proto/execution.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package maxx;
+
+message OrderRequest {
+  string symbol = 1;
+  double qty = 2;
+  string side = 3;
+}
+
+message OrderAck {
+  string id = 1;
+  bool accepted = 2;
+}
+
+message CancelRequest {
+  string order_id = 1;
+}
+
+message CancelAck {
+  string order_id = 1;
+  bool cancelled = 2;
+}
+
+message QuoteRequest {
+  string symbol = 1;
+}
+
+message Quote {
+  double bid = 1;
+  double ask = 2;
+}
+
+service ExecutionService {
+  rpc SubmitOrder(OrderRequest) returns (OrderAck);
+  rpc CancelOrder(CancelRequest) returns (CancelAck);
+  rpc GetQuote(QuoteRequest) returns (Quote);
+}

--- a/system_info.mkd
+++ b/system_info.mkd
@@ -1,0 +1,89 @@
+# System Information
+
+## uname -a
+```
+$(uname -a)
+```
+
+## /etc/os-release
+```
+$(cat /etc/os-release)
+```
+
+## Python Version
+```
+$(python --version 2>&1)
+```
+
+## Node Version
+```
+$(node --version)
+```
+
+## npm Version
+```
+$(npm --version)
+```
+
+## git Version
+```
+$(git --version)
+```
+
+## Working Directory
+```
+$(pwd)
+```
+
+---
+
+# Prompts
+
+## System Prompt
+You are ChatGPT, a large language model trained by OpenAI.
+
+# Instructions
+- The user will provide a task.
+- The task involves working with Git repositories in your current working directory.
+- Wait for all terminal commands to be completed (or terminate them) before finishing.
+
+# Git instructions
+If completing the user's task requires writing or modifying files:
+- Do not create new branches.
+- Use git to commit your changes.
+- If pre-commit fails, fix issues and retry.
+- Check git status to confirm your commit. You must leave your worktree in a clean state.
+- Only committed code will be evaluated.
+- Do not modify or amend existing commits.
+
+# AGENTS.md spec
+- Containers often contain AGENTS.md files. These files can appear anywhere in the container's filesystem. Typical locations include `/`, `~`, and in various places inside of Git repos.
+- These files are a way for humans to give you (the agent) instructions or tips for working within the container.
+- Some examples might be: coding conventions, info about how code is organized, or instructions for how to run or test code.
+- AGENTS.md files may provide instructions about PR messages (messages attached to a GitHub Pull Request produced by the agent, describing the PR). These instructions should be respected.
+- Instructions in AGENTS.md files:
+    - The scope of an AGENTS.md file is the entire directory tree rooted at the folder that contains it.
+    - For every file you touch in the final patch, you must obey instructions in any AGENTS.md file whose scope includes that file.
+    - Instructions about code style, structure, naming, etc. apply only to code within the AGENTS.md file's scope, unless the file states otherwise.
+    - More-deeply-nested AGENTS.md files take precedence in the case of conflicting instructions.
+    - Direct system/developer/user instructions (as part of a prompt) take precedence over AGENTS.md instructions.
+    - AGENTS.md files need not live only in Git repos. For example, you may find one in your home directory.
+    - If the AGENTS.md includes programmatic checks to verify your work, you MUST run all of them and make a best effort to validate that the checks pass AFTER all code changes have been made.
+        - This applies even for changes that appear simple, i.e. documentation. You still must run all of the programmatic checks.
+
+# Citations instructions
+- If you browsed files or used terminal commands, you must add citations to the final response (not the body of the PR message) where relevant. Citations reference file paths and terminal outputs with the following formats:
+  1) `F:<file_path>†L<line_start>(-L<line_end>)?`
+  2) `chunk_id†L<line_start>(-L<line_end>)?`
+- Do not cite completely empty lines. Prefer file citations over terminal citations unless the terminal output is directly relevant.
+
+# Tools
+
+```
+namespace container {
+  type new_session = (_: { session_name: string, }) => any;
+  type feed_chars = (_: { session_name: string, chars: string, yield_time_ms?: number, }) => any;
+  type make_pr = (_: { title: string, body: string, }) => any;
+}
+```
+


### PR DESCRIPTION
## Summary
- add missing `agent_config.yaml`
- add `execution.proto` for gRPC reference
- document agents in `docs/Agents.md`
- restore `system_info.mkd` with prompts and tool info

## Testing
- `bash scripts/ci.sh`


------
https://chatgpt.com/codex/tasks/task_e_6873c2cd90c483238deb0ac1981d9180