### PR TITLE
Fix timezone use in session clock

### DIFF
--- a/backend/services/session_clock.py
+++ b/backend/services/session_clock.py
@@ -5,6 +5,6 @@ from datetime import datetime, timezone
 
 def session_active() -> bool:
     """Return True if within London or New York trading hours."""
-    now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
     h = now.hour + now.minute / 60
     return (7 <= h < 16) or (12.5 <= h < 21)


### PR DESCRIPTION
## Summary
- ensure session clock uses timezone aware datetime

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f7ad1e294832387d6da0d641513ab