### PR TITLE
Add VaR to RiskSentinel

### DIFF
--- a/backend/services/risk_manager.py
+++ b/backend/services/risk_manager.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
 
 from backend.utils.settings import settings
 
@@ -55,3 +58,13 @@ class RiskSentinel:
 
     def intraday_dd(self) -> float:
         return max(0.0, 1 - self.balance / self.day_start)
+
+    def value_at_risk(self, *, confidence: float = 0.95) -> float:
+        """Return the historical Value-at-Risk at a given confidence level."""
+        if not self.fills:
+            return 0.0
+        pnl: Iterable[float] = (
+            f.qty * (f.price if f.side == "SELL" else -f.price) for f in self.fills
+        )
+        losses = [-p for p in pnl]
+        return float(np.quantile(list(losses), confidence))

--- a/backend/tests/test_risk_manager.py
+++ b/backend/tests/test_risk_manager.py
@@ -11,3 +11,10 @@ def test_drawdown_halt() -> None:
 def test_start_balance() -> None:
     risk = RiskSentinel(start_balance=500)
     assert risk.balance == 500
+
+
+def test_value_at_risk() -> None:
+    risk = RiskSentinel()
+    risk.update(Fill(order_id="1", symbol="BTCUSD", side="BUY", qty=1, price=100))
+    risk.update(Fill(order_id="2", symbol="BTCUSD", side="SELL", qty=1, price=90))
+    assert risk.value_at_risk(confidence=0.95) > 0


### PR DESCRIPTION
## Summary
- introduce `value_at_risk` method in `RiskSentinel`
- cover VaR logic with new unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f7ad1e294832387d6da0d641513ab