### PR TITLE
Improve health metrics and tests

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 
 from fastapi import FastAPI, WebSocket
 from starlette.websockets import WebSocketDisconnect
@@ -22,8 +23,15 @@ async def startup() -> None:
 
 
 @app.get("/healthz")
-async def healthz() -> dict[str, str]:
-    return {"status": "ok"}
+async def healthz() -> dict[str, float | str]:
+    """Return service health metrics."""
+    lag = engine.lag
+    reason = "" if lag < 5 else "feed lagging"
+    return {
+        "uptime": round(engine.uptime, 3),
+        "lag": round(lag, 3),
+        "reason": reason,
+    }
 
 
 @app.websocket("/ws/agents")

--- a/backend/services/trading_engine.py
+++ b/backend/services/trading_engine.py
@@ -34,7 +34,19 @@ class TradingEngine:
         self.alpha = AlphaEngine()
         self.router = Router()
         self.risk = risk or RiskSentinel()
+        self.start_time = time.monotonic()
+        self.last_tick = self.start_time
         self.ws_queues: list[asyncio.Queue[Any]] = []
+
+    @property
+    def uptime(self) -> float:
+        """Return engine uptime in seconds."""
+        return time.monotonic() - self.start_time
+
+    @property
+    def lag(self) -> float:
+        """Return seconds since last processed tick."""
+        return time.monotonic() - self.last_tick
 
     async def state_stream(self) -> Any:
         """Yield engine state for websocket clients."""
@@ -52,6 +64,7 @@ class TradingEngine:
 
     async def start(self) -> None:
         async for tick in self.tick_sub.stream():
+            self.last_tick = time.monotonic()
             self.alpha.update(tick.symbol, tick.price)
             if not session_active():
                 continue
@@ -92,6 +105,7 @@ class TradingEngine:
 
         count = 0
         async for tick in self.tick_sub.stream():
+            self.last_tick = time.monotonic()
             self.alpha.update(tick.symbol, tick.price)
             sent = await sentiment_factor()
             alpha = self.alpha.score(tick.symbol) * (1 + 0.5 * sent)

--- a/backend/tests/test_healthz.py
+++ b/backend/tests/test_healthz.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from backend.api.main import app
+
+
+def test_healthz_fields() -> None:
+    client = TestClient(app)
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert all(k in data for k in ["uptime", "lag", "reason"])


### PR DESCRIPTION
## Summary
- provide engine uptime and tick lag measurements
- expose detailed health metrics via `/healthz`
- cover health endpoint with a new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f7d9b38c883238c44d461ad8006bb